### PR TITLE
Radhakrishnan | MOBN-2401 | Fix undefined error popup

### DIFF
--- a/ui/app/clinical/consultation/controllers/consultationController.js
+++ b/ui/app/clinical/consultation/controllers/consultationController.js
@@ -284,7 +284,9 @@ angular.module('bahmni.clinical').controller('ConsultationController',
                     $window.open($scope.targetUrl, "_self");
                 }
                 $window.onbeforeunload = null;
-                $state.go($scope.toStateConfig.toState, $scope.toStateConfig.toParams);
+                if ($scope.toStateConfig) {
+                    $state.go($scope.toStateConfig.toState, $scope.toStateConfig.toParams);
+                }
                 ngDialog.close();
             };
 


### PR DESCRIPTION
Context: https://msfprojects.atlassian.net/browse/MOBN-2402

**Description:**
- when we click on `Don't Save` from the consultation tab for a program module, the program expects a `toStateConfig` scope to render the page, as it doesn't exists in our case, the red color popup was triggered with the error.